### PR TITLE
Build: clean up test workarounds after dependency updates

### DIFF
--- a/content/build.gradle.kts
+++ b/content/build.gradle.kts
@@ -163,10 +163,6 @@ tasks {
     }
 
     test {
-        classpath -= classpath.filter {
-            (it.name.startsWith("localization-") && it.name.endsWith(".jar")) // TODO[#63]: https://youtrack.jetbrains.com/issue/IJPL-178084/External-plugin-tests-break-due-to-localization-issues
-        }
-
         useTestNG()
         testLogging {
             showStandardStreams = true

--- a/content/build.gradle.kts
+++ b/content/build.gradle.kts
@@ -158,10 +158,6 @@ tasks {
         }
     }
 
-    prepareTestSandbox {
-        disabledPlugins.add("intellij.platform.ijent.impl") // TODO[#51]: Get rid of this after migration to 2025.1
-    }
-
     runIde {
         jvmArgs("-Xmx1500m")
     }
@@ -169,7 +165,6 @@ tasks {
     test {
         classpath -= classpath.filter {
             (it.name.startsWith("localization-") && it.name.endsWith(".jar")) // TODO[#63]: https://youtrack.jetbrains.com/issue/IJPL-178084/External-plugin-tests-break-due-to-localization-issues
-                || it.name == "cwm-plugin.jar" // TODO[#51]: Check after 251 EAP9 release
         }
 
         useTestNG()


### PR DESCRIPTION
- Closes #51.
- Closes #63.