### PR TITLE
Build: drop untilBuild as it is no longer needed for 2025.1+

### DIFF
--- a/content/build.gradle.kts
+++ b/content/build.gradle.kts
@@ -30,7 +30,6 @@ repositories {
 }
 
 val pluginVersion: String by project
-val untilBuildVersion: String by project
 val buildConfiguration: String by project
 val dotNetPluginId: String by project
 
@@ -121,7 +120,6 @@ tasks {
     }
 
     patchPluginXml {
-        untilBuild.set(untilBuildVersion)
         val latestChangelog = try {
             changelog.getUnreleased()
         } catch (_: MissingVersionException) {

--- a/content/gradle.properties
+++ b/content/gradle.properties
@@ -1,7 +1,5 @@
 pluginVersion=1.0.0
 
-untilBuildVersion=251.*
-
 buildConfiguration=Debug
 
 riderPluginId=com.jetbrains.rider.plugins.plugintemplate

--- a/intellij-updater.json
+++ b/intellij-updater.json
@@ -15,12 +15,6 @@
         "kind": "rider",
         "versionFlavor": "eap"
     }, {
-        "file": "content/gradle.properties",
-        "field": "untilBuildVersion",
-        "kind": "rider",
-        "versionFlavor": "release",
-        "augmentation": "nextMajor"
-    }, {
         "file": "content/gradle/libs.versions.toml",
         "field": "riderSdkPreview",
         "kind": "rider",


### PR DESCRIPTION
Closes #53.